### PR TITLE
Season 2024

### DIFF
--- a/.github/workflows/update-calendar.yml
+++ b/.github/workflows/update-calendar.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           composer install --no-dev --optimize-autoloader
           php app/run.php \
-              --season 2023 \
+              --season 2024 \
               --league "World Cups and World Championships" \
               --output "${{ env.CALENDAR_FILE_ICS }}" \
               --format "ics,json" \

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -87,15 +87,15 @@ services:
   nicoSWD\IfscCalendar\Infrastructure\Events\IFSCGuzzleEventsFetcher:
     class: nicoSWD\IfscCalendar\Infrastructure\Events\IFSCGuzzleEventsFetcher
     arguments:
-      - '@nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper'
+      - '@nicoSWD\IfscCalendar\Domain\Round\IFSCRoundsScraper'
       - '@nicoSWD\IfscCalendar\Infrastructure\HttpClient\HttpGuzzleClient'
       - '%site_event_url%'
 
-  nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper:
-    class: nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper
+  nicoSWD\IfscCalendar\Domain\Round\IFSCRoundsScraper:
+    class: nicoSWD\IfscCalendar\Domain\Round\IFSCRoundsScraper
     arguments:
       - '@nicoSWD\IfscCalendar\Infrastructure\HttpClient\HttpGuzzleClient'
-      - '@nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory'
+      - '@nicoSWD\IfscCalendar\Domain\Round\IFSCRoundFactory'
       - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\DOMHelper'
       - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer'
 
@@ -105,8 +105,8 @@ services:
   nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer:
     class: nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer
 
-  nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory:
-    class: nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory
+  nicoSWD\IfscCalendar\Domain\Round\IFSCRoundFactory:
+    class: nicoSWD\IfscCalendar\Domain\Round\IFSCRoundFactory
     arguments:
       - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer'
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -82,24 +82,20 @@ services:
 
   nicoSWD\IfscCalendar\Domain\Calendar\PostProcess\Season2023PostProcessor:
     class: nicoSWD\IfscCalendar\Domain\Calendar\PostProcess\Season2023PostProcessor
-    arguments:
-      - '@nicoSWD\IfscCalendar\Infrastructure\HttpClient\HttpGuzzleClient'
-      - '@nicoSWD\IfscCalendar\Domain\Event\IFSCEventFactory'
-      - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer'
-      - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\DOMHelper'
 
   # Events
   nicoSWD\IfscCalendar\Infrastructure\Events\IFSCGuzzleEventsFetcher:
     class: nicoSWD\IfscCalendar\Infrastructure\Events\IFSCGuzzleEventsFetcher
     arguments:
-      - '@nicoSWD\IfscCalendar\Domain\Event\IFSCEventsScraper'
+      - '@nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper'
       - '@nicoSWD\IfscCalendar\Infrastructure\HttpClient\HttpGuzzleClient'
+      - '%site_event_url%'
 
-  nicoSWD\IfscCalendar\Domain\Event\IFSCEventsScraper:
-    class: nicoSWD\IfscCalendar\Domain\Event\IFSCEventsScraper
+  nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper:
+    class: nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper
     arguments:
       - '@nicoSWD\IfscCalendar\Infrastructure\HttpClient\HttpGuzzleClient'
-      - '@nicoSWD\IfscCalendar\Domain\Event\IFSCEventFactory'
+      - '@nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory'
       - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\DOMHelper'
       - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer'
 
@@ -109,10 +105,9 @@ services:
   nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer:
     class: nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer
 
-  nicoSWD\IfscCalendar\Domain\Event\IFSCEventFactory:
-    class: nicoSWD\IfscCalendar\Domain\Event\IFSCEventFactory
+  nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory:
+    class: nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory
     arguments:
-      - '%site_event_url%'
       - '@nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer'
 
   # HTTP Client

--- a/src/Application/Command/BuildCommand.php
+++ b/src/Application/Command/BuildCommand.php
@@ -12,6 +12,7 @@ use nicoSWD\IfscCalendar\Application\UseCase\BuildCalendar\BuildCalendarResponse
 use nicoSWD\IfscCalendar\Application\UseCase\BuildCalendar\BuildCalendarUseCase;
 use nicoSWD\IfscCalendar\Application\UseCase\FetchSeasons\FetchSeasonsUseCase;
 use nicoSWD\IfscCalendar\Domain\Season\IFSCSeason;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -73,7 +74,7 @@ final class BuildCommand extends Command
             $pathInfo = pathinfo($fileName);
             $fileName = "{$pathInfo['dirname']}/{$pathInfo['filename']}.{$calFormat}";
 
-            $response = $this->buildCalendar($selectedSeason, $league, $calFormat, $output);
+            $response = $this->buildCalendar(IFSCSeasonYear::tryFrom($selectedSeason), $league, $calFormat, $output);
             $this->saveCalendar($fileName, $response->calendarContents, $output);
         }
 
@@ -83,7 +84,7 @@ final class BuildCommand extends Command
     }
 
     public function buildCalendar(
-        int $selectedSeason,
+        IFSCSeasonYear $selectedSeason,
         int $league,
         string $format,
         OutputInterface $output,

--- a/src/Application/UseCase/BuildCalendar/BuildCalendarRequest.php
+++ b/src/Application/UseCase/BuildCalendar/BuildCalendarRequest.php
@@ -7,10 +7,12 @@
  */
 namespace nicoSWD\IfscCalendar\Application\UseCase\BuildCalendar;
 
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
+
 final readonly class BuildCalendarRequest
 {
     public function __construct(
-        public int $season,
+        public IFSCSeasonYear $season,
         public int $league,
         public string $format,
     ) {

--- a/src/Domain/Calendar/IFSCCalendarBuilder.php
+++ b/src/Domain/Calendar/IFSCCalendarBuilder.php
@@ -10,6 +10,7 @@ namespace nicoSWD\IfscCalendar\Domain\Calendar;
 use nicoSWD\IfscCalendar\Domain\Calendar\Exceptions\NoEventsFoundException;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEventFetcherInterface;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeLinkFetcher;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeLinkMatcher;
 
@@ -25,7 +26,7 @@ final readonly class IFSCCalendarBuilder
     }
 
     /** @throws NoEventsFoundException */
-    public function generateForLeague(int $season, int $league, string $format): string
+    public function generateForLeague(IFSCSeasonYear $season, int $league, string $format): string
     {
         $events = $this->calendarPostProcess->process(
             season: $season,
@@ -42,7 +43,7 @@ final readonly class IFSCCalendarBuilder
     }
 
     /** @param IFSCEvent[] $events */
-    private function fetchEventStreamUrls(array &$events, int $season): void
+    private function fetchEventStreamUrls(array &$events, IFSCSeasonYear $season): void
     {
         $videoCollection = $this->linkFetcher->fetchRecentVideos($season);
 
@@ -62,7 +63,7 @@ final readonly class IFSCCalendarBuilder
     }
 
     /** @return IFSCEvent[] */
-    private function fetchEvents(int $season, int $league): array
+    private function fetchEvents(IFSCSeasonYear $season, int $league): array
     {
         return $this->eventFetcher->fetchEventsForLeague($season, $league);
     }

--- a/src/Domain/Calendar/IFSCCalendarBuilder.php
+++ b/src/Domain/Calendar/IFSCCalendarBuilder.php
@@ -46,21 +46,23 @@ final readonly class IFSCCalendarBuilder
     {
         $videoCollection = $this->linkFetcher->fetchRecentVideos($season);
 
-        foreach ($events as &$event) {
-            if ($event->streamUrl) {
-                continue;
-            }
+        foreach ($events as $event) {
+            foreach ($event->rounds as &$round) {
+                if ($round->streamUrl) {
+                    continue;
+                }
 
-            $streamUrl = $this->linkMatcher->findStreamUrlForEvent($event, $videoCollection);
+                $streamUrl = $this->linkMatcher->findStreamUrlForRound($round, $event, $videoCollection);
 
-            if ($streamUrl) {
-                $event = $event->updateStreamUrl($streamUrl);
+                if ($streamUrl) {
+                    $round = $round->updateStreamUrl($streamUrl);
+                }
             }
         }
     }
 
     /** @return IFSCEvent[] */
-    public function fetchEvents(int $season, int $league): array
+    private function fetchEvents(int $season, int $league): array
     {
         return $this->eventFetcher->fetchEventsForLeague($season, $league);
     }

--- a/src/Domain/Calendar/IFSCCalendarGeneratorInterface.php
+++ b/src/Domain/Calendar/IFSCCalendarGeneratorInterface.php
@@ -7,7 +7,10 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Calendar;
 
+use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
+
 interface IFSCCalendarGeneratorInterface
 {
+    /** @param IFSCEvent[] $events */
     public function generateForEvents(array $events): string;
 }

--- a/src/Domain/Calendar/IFSCCalendarPostProcess.php
+++ b/src/Domain/Calendar/IFSCCalendarPostProcess.php
@@ -7,6 +7,8 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Calendar;
 
+use Closure;
+use Exception;
 use nicoSWD\IfscCalendar\Domain\Calendar\PostProcess\Season2023PostProcessor;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
 
@@ -21,6 +23,7 @@ final readonly class IFSCCalendarPostProcess
      * @param int $season
      * @param IFSCEvent[] $events
      * @return IFSCEvent[]
+     * @throws Exception
      */
     public function process(int $season, array $events): array
     {
@@ -30,6 +33,19 @@ final readonly class IFSCCalendarPostProcess
                 break;
         }
 
+       $this->orderEvents($events);
+
         return $events;
+    }
+
+    /** @param IFSCEvent[] $events */
+    private function orderEvents(array &$events): void
+    {
+        usort($events, $this->orderByDate());
+    }
+
+    private function orderByDate(): Closure
+    {
+        return static fn (IFSCEvent $event1, IFSCEvent $event2) => $event1->startsAt <=> $event2->startsAt;
     }
 }

--- a/src/Domain/Calendar/IFSCCalendarPostProcess.php
+++ b/src/Domain/Calendar/IFSCCalendarPostProcess.php
@@ -11,6 +11,7 @@ use Closure;
 use Exception;
 use nicoSWD\IfscCalendar\Domain\Calendar\PostProcess\Season2023PostProcessor;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 
 final readonly class IFSCCalendarPostProcess
 {
@@ -20,17 +21,22 @@ final readonly class IFSCCalendarPostProcess
     }
 
     /**
-     * @param int $season
      * @param IFSCEvent[] $events
      * @return IFSCEvent[]
      * @throws Exception
      */
-    public function process(int $season, array $events): array
+    public function process(IFSCSeasonYear $season, array $events): array
     {
         switch ($season) {
-            case 2023:
+            case IFSCSeasonYear::SEASON_2020:
+            case IFSCSeasonYear::SEASON_2021:
+            case IFSCSeasonYear::SEASON_2022:
+                break;
+            case IFSCSeasonYear::SEASON_2023:
                 $events = $this->season2023PostProcessor->process($events);
                 break;
+            case IFSCSeasonYear::SEASON_2024:
+            case IFSCSeasonYear::SEASON_2025:
         }
 
        $this->orderEvents($events);

--- a/src/Domain/Calendar/PostProcess/Season2023PostProcessor.php
+++ b/src/Domain/Calendar/PostProcess/Season2023PostProcessor.php
@@ -11,7 +11,7 @@ use DateTime;
 use DateTimeImmutable;
 use Exception;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
 
 final readonly class Season2023PostProcessor
 {

--- a/src/Domain/Calendar/PostProcess/Season2023PostProcessor.php
+++ b/src/Domain/Calendar/PostProcess/Season2023PostProcessor.php
@@ -7,119 +7,125 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Calendar\PostProcess;
 
-use Closure;
-use DOMElement;
-use DOMNodeList;
-use nicoSWD\IfscCalendar\Domain\Event\Helpers\DOMHelper;
-use nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer;
+use DateTime;
+use DateTimeImmutable;
+use Exception;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCEventFactory;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCSchedule;
-use nicoSWD\IfscCalendar\Domain\Event\Month;
-use nicoSWD\IfscCalendar\Domain\HttpClient\HttpClientInterface;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
 
 final readonly class Season2023PostProcessor
 {
-    private const BERN_SCHEDULE_URL = 'https://www.ifsc-climbing.org/bern-2023/schedule';
-    private const BERN_XPATH_EVENTS = "//div[contains(@class, 'js-filter')]/div[@data-tag]";
     private const BERN_IFSC_EVENT_ID = 1301;
-    private const BERN_IFSC_EVENT_DESCRIPTION = 'IFSC World Championships Bern 2023';
-    private const BERN_IFSC_2023_POSTER = 'https://ifsc.stream/img/posters/bern2023.jpg';
-    private const BERN_TIMEZONE = 'Europe/Zurich';
-    private const BERN_IDENTIFIER = 'Bern (SUI)';
-
-    public function __construct(
-        private HttpClientInterface $httpClient,
-        private IFSCEventFactory $eventFactory,
-        private Normalizer $normalizer,
-        private DOMHelper $DOMHelper,
-    ) {
-    }
 
     /**
      * @param IFSCEvent[] $events
      * @return IFSCEvent[]
+     * @throws Exception
      */
     public function process(array $events): array
     {
-        // Add missing Bern events, which are listed on a separate page in an
-        // entirely different format. Thanks, y'all.
-        if (!$this->hasBernEvents($events)) {
-            $events = array_merge($events, $this->fetchBernEvents());
+        foreach ($events as $event) {
+            if ($this->isBernEvent($event)) {
+                $event->rounds = $this->fetchBernEvents();
+            }
         }
 
         return $events;
     }
 
-    /** @return IFSCEvent[] */
+    /**
+     * @return IFSCRound[]
+     * @throws Exception
+     */
     private function fetchBernEvents(): array
     {
-        $events = [];
-
-        foreach ($this->fetchEventsFromHTML() as $event) {
-            $schedule = $this->createSchedule(
-                sscanf($this->normalizeEventLine($event), '%d %s || %d:%d %[^$]s')
-            );
-
-            $events[] = $this->eventFactory->create(
-                name: $this->normalizer->cupName($schedule->cupName),
-                id: self::BERN_IFSC_EVENT_ID,
-                description: self::BERN_IFSC_EVENT_DESCRIPTION,
-                streamUrl: $this->extractStreamUrl($event),
-                poster: self::BERN_IFSC_2023_POSTER,
-                startTime: $schedule->duration->startTime,
-                endTime: $schedule->duration->endTime,
-            );
-        }
-
-        return $events;
+        return [
+            $this->createRound(
+                name: "Men's Boulder Qualification",
+                startTime: "2023-08-01T09:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Women's Lead Qualification",
+                startTime: "2023-08-02T11:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Men's Lead Qualification",
+                startTime: "2023-08-03T08:30:00+02:00",
+            ),
+            $this->createRound(
+                name: "Women's Boulder Qualification",
+                startTime: "2023-08-03T15:30:00+02:00",
+            ),
+            $this->createRound(
+                name: "Men's Boulder Semi-final",
+                startTime: "2023-08-04T10:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Men's Boulder Final",
+                startTime: "2023-08-04T18:30:00+02:00",
+            ),
+            $this->createRound(
+                name: "Women's Boulder Semi-final",
+                startTime: "2023-08-05T10:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Women's Boulder Final",
+                startTime: "2023-08-05T18:30:00+02:00",
+            ),
+            $this->createRound(
+                name: "Lead Semi-finals",
+                startTime: "2023-08-06T10:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Lead Finals",
+                startTime: "2023-08-06T18:30:00+02:00",
+            ),
+            $this->createRound(
+                name: "Women's Boulder & Lead Semi-final",
+                startTime: "2023-08-09T09:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Men's Boulder & Lead Semi-final",
+                startTime: "2023-08-09T13:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Boulder & Lead Semi-finals",
+                startTime: "2023-08-09T20:30:00+02:00",
+            ),
+            $this->createRound(
+                name: "Speed Qualifications",
+                startTime: "2023-08-10T09:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Speed Finals",
+                startTime: "2023-08-10T20:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Women's Boulder & Lead Final",
+                startTime: "2023-08-11T19:00:00+02:00",
+            ),
+            $this->createRound(
+                name: "Men's Boulder & Lead Final",
+                startTime: "2023-08-12T16:00:00+02:00",
+            ),
+        ];
     }
 
-    private function createSchedule(array $eventLine): IFSCSchedule
+    /** @throws Exception */
+    private function createRound(string $name, string $startTime): IFSCRound
     {
-        [$day, $month, $hour, $minute, $cupName] = $eventLine;
+        $startTime = new DateTime($startTime);
 
-        return IFSCSchedule::create(
-            day: $day,
-            month: Month::fromName($month),
-            time: "$hour:$minute",
-            timeZone: self::BERN_TIMEZONE,
-            season: 2023,
-            cupName: $cupName,
+        return new IFSCRound(
+            name: $name,
+            streamUrl: null,
+            startTime: DateTimeImmutable::createFromMutable($startTime),
+            endTime: DateTimeImmutable::createFromMutable($startTime->modify('+3 hours')),
         );
     }
 
-    private function fetchEventsFromHTML(): DOMNodeList
+    private function isBernEvent(IFSCEvent $event): bool
     {
-        $xpath = $this->DOMHelper->htmlToXPath(
-            $this->httpClient->getRetry(self::BERN_SCHEDULE_URL)
-        );
-
-        return $xpath->query(self::BERN_XPATH_EVENTS);
-    }
-
-    private function normalizeEventLine(DOMElement $event): string
-    {
-        return $this->normalizer->removeMultipleSpaces(
-            explode("\n", $event->nodeValue)[0]
-        );
-    }
-
-    /** @param IFSCEvent[] $events */
-    private function hasBernEvents(array $events): bool
-    {
-        return count(array_filter($events, $this->isBernEvent())) > 0;
-    }
-
-    private function isBernEvent(): Closure
-    {
-        return static fn(IFSCEvent $event): bool => str_contains($event->name, self::BERN_IDENTIFIER);
-    }
-
-    private function extractStreamUrl(DOMElement $event): string
-    {
-        return $this->normalizer->normalizeStreamUrl(
-            explode("\n", $event->textContent)[1]
-        );
+        return $event->eventId === self::BERN_IFSC_EVENT_ID;
     }
 }

--- a/src/Domain/Event/Exceptions/IFSCEventsScraperException.php
+++ b/src/Domain/Event/Exceptions/IFSCEventsScraperException.php
@@ -11,13 +11,4 @@ use Exception;
 
 final class IFSCEventsScraperException extends Exception
 {
-    public static function timeParseExceptionForEventWithId(string $time, int $eventId): self
-    {
-        return new self("Unable to parse time '{$time}' for event with ID '{$eventId}'");
-    }
-
-    public static function noEventsScrapedForEventWithName(string $eventName): self
-    {
-        return new self("Unable to scrape events for ID '{$eventName}'");
-    }
 }

--- a/src/Domain/Event/Helpers/DOMHelper.php
+++ b/src/Domain/Event/Helpers/DOMHelper.php
@@ -19,6 +19,8 @@ final readonly class DOMHelper
 
     private const XPATH_EVENT_DATE_RANGE = "//div[@class='title']/h2[@class='date_span']";
 
+    private const REGEX_EVENT_POSTER = '~^(?:https://(?:cdn|www)\.ifsc-climbing\.org)?(?<path>/images/Events/[^$]+)~';
+
     public function htmlToXPath(string $html): DOMXPath
     {
         $lastValue = libxml_use_internal_errors(true);
@@ -78,7 +80,7 @@ final readonly class DOMHelper
 
     private function hasPosterPrefix(string $textContent, ?array &$match): bool
     {
-        if (preg_match('~^(?:https://(?:cdn|www)\.ifsc-climbing\.org)?(?<path>/images/Events/[^$]+)~', $textContent, $match) === 1) {
+        if (preg_match(self::REGEX_EVENT_POSTER, $textContent, $match) === 1) {
             return true;
         }
 

--- a/src/Domain/Event/Helpers/DOMHelper.php
+++ b/src/Domain/Event/Helpers/DOMHelper.php
@@ -71,6 +71,15 @@ final readonly class DOMHelper
 
     private function hasPosterPrefix(string $textContent, &$match): bool
     {
-        return preg_match('~^(?:https://(?:cdn|www)\.ifsc-climbing\.org)?(?<path>/images/Events/[^$]+)~', $textContent, $match) === 1;
+        if (preg_match('~^(?:https://(?:cdn|www)\.ifsc-climbing\.org)?(?<path>/images/Events/[^$]+)~', $textContent, $match)) {
+            return true;
+        }
+
+        if (str_contains($textContent, 'Events')) {
+            $match['path'] = $textContent;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Domain/Event/Helpers/DOMHelper.php
+++ b/src/Domain/Event/Helpers/DOMHelper.php
@@ -17,6 +17,8 @@ final readonly class DOMHelper
 
     private const XPATH_SIDEBAR = "//div[@class='text2']";
 
+    private const XPATH_EVENT_DATE_RANGE = "//div[@class='title']/h2[@class='date_span']";
+
     public function htmlToXPath(string $html): DOMXPath
     {
         $lastValue = libxml_use_internal_errors(true);
@@ -50,6 +52,11 @@ final readonly class DOMHelper
         return null;
     }
 
+    public function getDateRange(DOMXPath $xpath): string
+    {
+        return trim($xpath->query(self::XPATH_EVENT_DATE_RANGE)->item(0)->textContent);
+    }
+
     private function normalizeHtml(string $html): string
     {
         $find = [
@@ -69,9 +76,9 @@ final readonly class DOMHelper
         return preg_replace($find, $replace, $html);
     }
 
-    private function hasPosterPrefix(string $textContent, &$match): bool
+    private function hasPosterPrefix(string $textContent, ?array &$match): bool
     {
-        if (preg_match('~^(?:https://(?:cdn|www)\.ifsc-climbing\.org)?(?<path>/images/Events/[^$]+)~', $textContent, $match)) {
+        if (preg_match('~^(?:https://(?:cdn|www)\.ifsc-climbing\.org)?(?<path>/images/Events/[^$]+)~', $textContent, $match) === 1) {
             return true;
         }
 

--- a/src/Domain/Event/Helpers/Normalizer.php
+++ b/src/Domain/Event/Helpers/Normalizer.php
@@ -57,11 +57,6 @@ final readonly class Normalizer
         return preg_replace('~[\r\n]+~', ' ', $string);
     }
 
-    public function removeMultipleSpaces(string $string): string
-    {
-        return preg_replace('~\s{2,}~', ' ', trim($string));
-    }
-
     public function normalizeStreamUrl(string $streamUrl): string
     {
         $regex = '~youtu(\.be|be\.com)/(live/|watch\?v=)?(?<video_id>[a-zA-Z0-9_-]{10,})~';

--- a/src/Domain/Event/IFSCEvent.php
+++ b/src/Domain/Event/IFSCEvent.php
@@ -7,33 +7,22 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Event;
 
-use DateTimeImmutable;
-
-final readonly class IFSCEvent
+final class IFSCEvent
 {
+    /** @param IFSCRound[] $rounds */
     public function __construct(
-        public string $name,
-        public int $id,
-        public string $description,
-        public string $streamUrl,
-        public string $siteUrl,
-        public string $poster,
-        public DateTimeImmutable $startTime,
-        public DateTimeImmutable $endTime,
+        public readonly int $season,
+        public readonly int $eventId,
+        public readonly string $timeZone,
+        public readonly string $eventName,
+        public readonly string $location,
+        public readonly string $country,
+        public readonly ?string $poster,
+        public readonly string $siteUrl,
+        public readonly string $startsAt,
+        public readonly string $endsAt,
+        public readonly array $disciplines,
+        public array $rounds,
     ) {
-    }
-
-    public function updateStreamUrl(string $streamUrl): self
-    {
-        return new self(
-            name: $this->name,
-            id: $this->id,
-            description: $this->description,
-            streamUrl: $streamUrl,
-            siteUrl: $this->siteUrl,
-            poster: $this->poster,
-            startTime: $this->startTime,
-            endTime: $this->endTime,
-        );
     }
 }

--- a/src/Domain/Event/IFSCEvent.php
+++ b/src/Domain/Event/IFSCEvent.php
@@ -7,11 +7,16 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Event;
 
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
+use nicoSWD\IfscCalendar\Domain\Starter\IFSCStarter;
+
 final class IFSCEvent
 {
     /** @param IFSCRound[] $rounds */
+    /** @param IFSCStarter[] $starters */
     public function __construct(
-        public readonly int $season,
+        public readonly IFSCSeasonYear $season,
         public readonly int $eventId,
         public readonly string $timeZone,
         public readonly string $eventName,
@@ -23,6 +28,7 @@ final class IFSCEvent
         public readonly string $endsAt,
         public readonly array $disciplines,
         public array $rounds,
+        public array $starters = [],
     ) {
     }
 }

--- a/src/Domain/Event/IFSCEventDuration.php
+++ b/src/Domain/Event/IFSCEventDuration.php
@@ -10,6 +10,7 @@ namespace nicoSWD\IfscCalendar\Domain\Event;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 
 final readonly class IFSCEventDuration
 {
@@ -24,13 +25,13 @@ final readonly class IFSCEventDuration
         Month $month,
         string $time,
         string $timeZone,
-        int $season,
+        IFSCSeasonYear $season,
     ): self {
         [$hour, $minute] = sscanf($time, '%d:%d');
 
         $date = new DateTime();
         $date->setTimezone(new DateTimeZone($timeZone));
-        $date->setDate($season, $month->value, $day);
+        $date->setDate($season->value, $month->value, $day);
         $date->setTime($hour, $minute);
 
         $startTime = DateTimeImmutable::createFromMutable($date);

--- a/src/Domain/Event/IFSCEventFetcherInterface.php
+++ b/src/Domain/Event/IFSCEventFetcherInterface.php
@@ -7,8 +7,10 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Event;
 
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
+
 interface IFSCEventFetcherInterface
 {
     /** @return IFSCEvent[] */
-    public function fetchEventsForLeague(int $season, int $leagueId): array;
+    public function fetchEventsForLeague(IFSCSeasonYear $season, int $leagueId): array;
 }

--- a/src/Domain/Event/IFSCEventFetcherInterface.php
+++ b/src/Domain/Event/IFSCEventFetcherInterface.php
@@ -10,5 +10,5 @@ namespace nicoSWD\IfscCalendar\Domain\Event;
 interface IFSCEventFetcherInterface
 {
     /** @return IFSCEvent[] */
-    public function fetchEventsForLeague(int $season, int $league): array;
+    public function fetchEventsForLeague(int $season, int $leagueId): array;
 }

--- a/src/Domain/Event/IFSCRound.php
+++ b/src/Domain/Event/IFSCRound.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license  http://opensource.org/licenses/mit-license.php MIT
+ * @link     https://github.com/nicoSWD
+ * @author   Nicolas Oelgart <nico@oelgart.com>
+ */
+namespace nicoSWD\IfscCalendar\Domain\Event;
+
+use DateTimeImmutable;
+
+final readonly class IFSCRound
+{
+    public function __construct(
+        public string $name,
+        public ?string $streamUrl,
+        public DateTimeImmutable $startTime,
+        public DateTimeImmutable $endTime,
+        public bool $scheduleConfirmed = true,
+    ) {
+    }
+
+    public function updateStreamUrl(string $streamUrl): self
+    {
+        return new self(
+            name: $this->name,
+            streamUrl: $streamUrl,
+            startTime: $this->startTime,
+            endTime: $this->endTime,
+            scheduleConfirmed: $this->scheduleConfirmed,
+        );
+    }
+}

--- a/src/Domain/Event/IFSCRoundFactory.php
+++ b/src/Domain/Event/IFSCRoundFactory.php
@@ -7,52 +7,28 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Event;
 
-use Closure;
 use DateTimeImmutable;
 use nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer;
 
-final readonly class IFSCEventFactory
+final readonly class IFSCRoundFactory
 {
     public function __construct(
-        private string $siteUrl,
         private Normalizer $normalizer,
     ) {
     }
 
     public function create(
         string $name,
-        int $id,
-        string $description,
         string $streamUrl,
-        string $poster,
         DateTimeImmutable $startTime,
         DateTimeImmutable $endTime,
-    ): IFSCEvent {
-        return new IFSCEvent(
+    ): IFSCRound {
+        return new IFSCRound(
             name: $name,
-            id: $id,
-            description: $description,
             streamUrl: $this->getStreamUrl($streamUrl),
-            siteUrl: $this->getSiteUrl($startTime, $id),
-            poster: $poster,
             startTime: $startTime,
             endTime: $endTime,
         );
-    }
-
-    private function getSiteUrl(DateTimeImmutable $startTime, int $id): string
-    {
-        $params = [
-            'season' => $startTime->format('Y'),
-            'event_id' => $id,
-        ];
-
-        return preg_replace_callback('~{(?<var_name>season|event_id)}~', $this->replaceVariables($params), $this->siteUrl);
-    }
-
-    private function replaceVariables(array $params): Closure
-    {
-        return static fn (array $match): string => (string) $params[$match['var_name']];
     }
 
     private function getStreamUrl(string $streamUrl): string

--- a/src/Domain/Event/IFSCSchedule.php
+++ b/src/Domain/Event/IFSCSchedule.php
@@ -8,6 +8,7 @@
 namespace nicoSWD\IfscCalendar\Domain\Event;
 
 use nicoSWD\IfscCalendar\Domain\Event\Exceptions\InvalidURLException;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 
 final readonly class IFSCSchedule
 {
@@ -24,7 +25,7 @@ final readonly class IFSCSchedule
         Month $month,
         string $time,
         string $timeZone,
-        int $season,
+        IFSCSeasonYear $season,
         string $cupName,
         string $streamUrl = '',
     ): self  {

--- a/src/Domain/Event/IFSCScrapedEventsResult.php
+++ b/src/Domain/Event/IFSCScrapedEventsResult.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license  http://opensource.org/licenses/mit-license.php MIT
+ * @link     https://github.com/nicoSWD
+ * @author   Nicolas Oelgart <nico@oelgart.com>
+ */
+namespace nicoSWD\IfscCalendar\Domain\Event;
+
+final readonly class IFSCScrapedEventsResult
+{
+    /** @param IFSCRound[] $rounds */
+    public function __construct(
+        public ?string $poster,
+        public array $rounds,
+    ) {
+    }
+}

--- a/src/Domain/Event/IFSCScrapedEventsResult.php
+++ b/src/Domain/Event/IFSCScrapedEventsResult.php
@@ -7,12 +7,15 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\Event;
 
+use DateTimeImmutable;
 use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
 
 final readonly class IFSCScrapedEventsResult
 {
     /** @param IFSCRound[] $rounds */
     public function __construct(
+        public DateTimeImmutable $startDate,
+        public DateTimeImmutable $endDate,
         public ?string $poster,
         public array $rounds,
     ) {

--- a/src/Domain/Round/IFSCRound.php
+++ b/src/Domain/Round/IFSCRound.php
@@ -5,7 +5,7 @@
  * @link     https://github.com/nicoSWD
  * @author   Nicolas Oelgart <nico@oelgart.com>
  */
-namespace nicoSWD\IfscCalendar\Domain\Event;
+namespace nicoSWD\IfscCalendar\Domain\Round;
 
 use DateTimeImmutable;
 

--- a/src/Domain/Round/IFSCRoundFactory.php
+++ b/src/Domain/Round/IFSCRoundFactory.php
@@ -5,7 +5,7 @@
  * @link     https://github.com/nicoSWD
  * @author   Nicolas Oelgart <nico@oelgart.com>
  */
-namespace nicoSWD\IfscCalendar\Domain\Event;
+namespace nicoSWD\IfscCalendar\Domain\Round;
 
 use DateTimeImmutable;
 use nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer;

--- a/src/Domain/Round/IFSCRoundsScraper.php
+++ b/src/Domain/Round/IFSCRoundsScraper.php
@@ -39,10 +39,10 @@ final readonly class IFSCRoundsScraper
      */
     public function fetchRoundsAndPosterForEvent(IFSCSeasonYear $season, int $eventId, string $timeZone): IFSCScrapedEventsResult
     {
-        $xpath = $this->getXPathForEventsWithId($eventId);
-        $dateRegex = $this->buildDateRegex();
         /** @var IFSCSchedule[] $schedules */
         $schedules = [];
+        $dateRegex = $this->buildDateRegex();
+        $xpath = $this->getXPathForEventsWithId($eventId);
 
         foreach ($this->domHelper->getParagraphs($xpath) as $paragraph) {
             if (!preg_match_all($dateRegex, $this->normalizeParagraph($paragraph), $matches)) {

--- a/src/Domain/Season/IFSCSeasonYear.php
+++ b/src/Domain/Season/IFSCSeasonYear.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license  http://opensource.org/licenses/mit-license.php MIT
+ * @link     https://github.com/nicoSWD
+ * @author   Nicolas Oelgart <nico@oelgart.com>
+ */
+namespace nicoSWD\IfscCalendar\Domain\Season;
+
+enum IFSCSeasonYear: int
+{
+    case SEASON_2020 = 2020;
+    case SEASON_2021 = 2021;
+    case SEASON_2022 = 2022;
+    case SEASON_2023 = 2023;
+    case SEASON_2024 = 2024;
+    case SEASON_2025 = 2025;
+}

--- a/src/Domain/Starter/IFSCStarter.php
+++ b/src/Domain/Starter/IFSCStarter.php
@@ -5,16 +5,16 @@
  * @link     https://github.com/nicoSWD
  * @author   Nicolas Oelgart <nico@oelgart.com>
  */
-namespace nicoSWD\IfscCalendar\Domain\Event;
+namespace nicoSWD\IfscCalendar\Domain\Starter;
 
-use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
-
-final readonly class IFSCScrapedEventsResult
+final readonly class IFSCStarter
 {
-    /** @param IFSCRound[] $rounds */
     public function __construct(
-        public ?string $poster,
-        public array $rounds,
+        public string $firstName,
+        public string $lastName,
+        public string $country,
+        public float $score,
+        public ?string $photoUrl,
     ) {
     }
 }

--- a/src/Domain/YouTube/YouTubeApiClient.php
+++ b/src/Domain/YouTube/YouTubeApiClient.php
@@ -7,7 +7,9 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\YouTube;
 
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
+
 interface YouTubeApiClient
 {
-    public function fetchRecentVideos(int $season): YouTubeVideoCollection;
+    public function fetchRecentVideos(IFSCSeasonYear $season): YouTubeVideoCollection;
 }

--- a/src/Domain/YouTube/YouTubeLinkFetcher.php
+++ b/src/Domain/YouTube/YouTubeLinkFetcher.php
@@ -7,6 +7,8 @@
  */
 namespace nicoSWD\IfscCalendar\Domain\YouTube;
 
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
+
 final readonly class YouTubeLinkFetcher
 {
     public function __construct(
@@ -14,7 +16,7 @@ final readonly class YouTubeLinkFetcher
     ) {
     }
 
-    public function fetchRecentVideos(int $season): YouTubeVideoCollection
+    public function fetchRecentVideos(IFSCSeasonYear $season): YouTubeVideoCollection
     {
         return $this->api->fetchRecentVideos($season);
     }

--- a/src/Domain/YouTube/YouTubeLinkMatcher.php
+++ b/src/Domain/YouTube/YouTubeLinkMatcher.php
@@ -15,9 +15,6 @@ final readonly class YouTubeLinkMatcher
 {
     private const YOUTUBE_BASE_URL = 'https://youtu.be/';
 
-    // Eg: "ifsc world cup koper 2023
-    private const REGEX_LOCATION_AND_SEASON = '~^IFSC World (?:Cup|Championships?) (?<location>.+) (?<season>20\d{2})$~i';
-
     public function findStreamUrlForRound(IFSCRound $round, IFSCEvent $event, YouTubeVideoCollection $videoCollection): ?string
     {
         foreach ($videoCollection->getIterator() as $video) {
@@ -31,8 +28,8 @@ final readonly class YouTubeLinkMatcher
 
     private function videoTitleMatchesRoundName(YouTubeVideo $video, IFSCRound $round, IFSCEvent $event): bool
     {
-        $videoTitle = strtolower($video->title);
-        $roundName = strtolower($round->name);
+        $videoTitle = mb_strtolower($video->title);
+        $roundName = mb_strtolower($round->name);
 
         if (!$this->videoTitleContainsSameLocationAndSeason($videoTitle, $event)) {
             return false;
@@ -66,31 +63,11 @@ final readonly class YouTubeLinkMatcher
         return $tags;
     }
 
-    private function getLocationAndSeason(IFSCEvent $event): ?array
-    {
-        if (preg_match(self::REGEX_LOCATION_AND_SEASON, strtolower($event->eventName), $eventDetails)) {
-            return [
-                $eventDetails['location'],
-                $eventDetails['season'],
-            ];
-        }
-
-        return null;
-    }
-
     private function videoTitleContainsSameLocationAndSeason(string $videoTitle, IFSCEvent $event): bool
     {
-        $locationAndSeason = $this->getLocationAndSeason($event);
-
-        if (!$locationAndSeason) {
-            return false;
-        }
-
-        [$location, $season] = $locationAndSeason;
-
         return
-            str_contains($videoTitle, $location) &&
-            str_contains($videoTitle, $season);
+            str_contains($videoTitle, mb_strtolower($event->location)) &&
+            str_contains($videoTitle, (string) $event->season->value);
     }
 
     private function videoIsHighlights(array $videoTags): bool

--- a/src/Domain/YouTube/YouTubeLinkMatcher.php
+++ b/src/Domain/YouTube/YouTubeLinkMatcher.php
@@ -8,7 +8,7 @@
 namespace nicoSWD\IfscCalendar\Domain\YouTube;
 
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEventTagsRegex as Tag;
 
 final readonly class YouTubeLinkMatcher

--- a/src/Infrastructure/Calendar/ICalCalendar.php
+++ b/src/Infrastructure/Calendar/ICalCalendar.php
@@ -124,6 +124,13 @@ final readonly class ICalCalendar implements IFSCCalendarGeneratorInterface
             $description .= "⚠️ Precise schedule has not been announced yet. This calendar will update automatically once it's published!\n\n";
         }
 
+        $description .= "Disciplines:\n";
+
+        foreach ($event->disciplines as $discipline) {
+            $description .= " - " . ucfirst($discipline) ."\n";
+        }
+
+        $description .= "\n";
         $description.= "Stream URL:\n{$event->siteUrl}\n";
 
         if ($event->starters) {

--- a/src/Infrastructure/Calendar/ICalCalendar.php
+++ b/src/Infrastructure/Calendar/ICalCalendar.php
@@ -18,7 +18,7 @@ use Eluceo\iCal\Presentation\Factory\CalendarFactory;
 use Exception;
 use nicoSWD\IfscCalendar\Domain\Calendar\IFSCCalendarGeneratorInterface;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
 
 final readonly class ICalCalendar implements IFSCCalendarGeneratorInterface
 {

--- a/src/Infrastructure/Calendar/JsonCalendar.php
+++ b/src/Infrastructure/Calendar/JsonCalendar.php
@@ -8,43 +8,74 @@
 namespace nicoSWD\IfscCalendar\Infrastructure\Calendar;
 
 use DateTime;
-use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
+use Exception;
 use nicoSWD\IfscCalendar\Domain\Calendar\IFSCCalendarGeneratorInterface;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
 
 final readonly class JsonCalendar implements IFSCCalendarGeneratorInterface
 {
     private const IFSC_EVENT_INFO_URL = 'https://www.ifsc-climbing.org/component/ifsc/?view=event&WetId=%d';
 
-    /** @param IFSCEvent[] $events */
+    /**
+     * @inheritDoc
+     * @throws Exception
+     */
     public function generateForEvents(array $events): string
     {
         $jsonEvents = ['events' => []];
 
         foreach ($events as $event) {
             $jsonEvents['events'][] = [
-                'id' => $event->id,
-                'name' => $event->name,
-                'description' => $event->description,
+                'id' => $event->eventId,
+                'season' => $event->season,
+                'name' => $event->eventName,
+                'country' => $event->country,
+                'location' => $event->location,
                 'poster' => $event->poster,
-                'stream_url' => $event->streamUrl,
-                'event_url' => $this->buildUrl($event),
                 'site_url' => $event->siteUrl,
-                'start_time' => $this->formatDate($event->startTime),
+                'event_url' => $this->buildUrl($event),
+                'disciplines' => $event->disciplines,
+                'starts_at' => $this->formatDate($event->startsAt, $event->timeZone),
+                'ends_at' => $this->formatDate($event->endsAt, $event->timeZone),
+                'timezone' => $event->timeZone,
+                'rounds' => $this->formatRound($event->rounds),
             ];
         }
 
         return json_encode($jsonEvents, flags: JSON_PRETTY_PRINT);
     }
 
-    private function buildUrl(IFSCEvent $event): string
+    /**
+     * @param IFSCRound[] $rounds
+     * @return IFSCRound[]
+     */
+    private function formatRound(array $rounds): array
     {
-        return sprintf(self::IFSC_EVENT_INFO_URL, $event->id);
+        $format = static fn (IFSCRound $round): array => [
+            'name' => $round->name,
+            'stream_url' => $round->streamUrl,
+            'starts_at' => $round->startTime->format(DateTimeInterface::RFC3339),
+            'ends_at' => $round->endTime->format(DateTimeInterface::RFC3339),
+            'schedule_confirmed' => $round->scheduleConfirmed,
+        ];
+
+        return array_map($format, $rounds);
     }
 
-    public function formatDate(DateTimeImmutable $date): string
+    private function buildUrl(IFSCEvent $event): string
     {
-        return DateTime::createFromImmutable($date)->format(DateTimeInterface::RFC3339);
+        return sprintf(self::IFSC_EVENT_INFO_URL, $event->eventId);
+    }
+
+    /** @throws Exception */
+    private function formatDate(string $date, string $timeZone): string
+    {
+        $dateTime = new DateTime($date);
+        $dateTime->setTimezone(new DateTimeZone($timeZone));
+
+        return $dateTime->format(DateTimeInterface::RFC3339);
     }
 }

--- a/src/Infrastructure/Calendar/JsonCalendar.php
+++ b/src/Infrastructure/Calendar/JsonCalendar.php
@@ -43,7 +43,7 @@ final readonly class JsonCalendar implements IFSCCalendarGeneratorInterface
                 'ends_at' => $this->formatDate($event->endsAt, $event->timeZone),
                 'timezone' => $event->timeZone,
                 'rounds' => $this->formatRound($event->rounds),
-                'starters' => $this->formatStarters($event->starters),
+                'start_list' => $this->formatStarters($event->starters),
             ];
         }
 

--- a/src/Infrastructure/Calendar/JsonCalendar.php
+++ b/src/Infrastructure/Calendar/JsonCalendar.php
@@ -13,7 +13,8 @@ use DateTimeZone;
 use Exception;
 use nicoSWD\IfscCalendar\Domain\Calendar\IFSCCalendarGeneratorInterface;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Starter\IFSCStarter;
 
 final readonly class JsonCalendar implements IFSCCalendarGeneratorInterface
 {
@@ -30,7 +31,7 @@ final readonly class JsonCalendar implements IFSCCalendarGeneratorInterface
         foreach ($events as $event) {
             $jsonEvents['events'][] = [
                 'id' => $event->eventId,
-                'season' => $event->season,
+                'season' => $event->season->value,
                 'name' => $event->eventName,
                 'country' => $event->country,
                 'location' => $event->location,
@@ -42,6 +43,7 @@ final readonly class JsonCalendar implements IFSCCalendarGeneratorInterface
                 'ends_at' => $this->formatDate($event->endsAt, $event->timeZone),
                 'timezone' => $event->timeZone,
                 'rounds' => $this->formatRound($event->rounds),
+                'starters' => $this->formatStarters($event->starters),
             ];
         }
 
@@ -63,6 +65,18 @@ final readonly class JsonCalendar implements IFSCCalendarGeneratorInterface
         ];
 
         return array_map($format, $rounds);
+    }
+
+    private function formatStarters(array $starters): array
+    {
+        $format = static fn (IFSCStarter $starter): array => [
+            'first_name' => $starter->firstName,
+            'last_name' => $starter->lastName,
+            'country' => $starter->country,
+            'photo_url' => $starter->photoUrl,
+        ];
+
+        return array_map($format, $starters);
     }
 
     private function buildUrl(IFSCEvent $event): string

--- a/src/Infrastructure/Events/IFSCGuzzleEventsFetcher.php
+++ b/src/Infrastructure/Events/IFSCGuzzleEventsFetcher.php
@@ -9,7 +9,6 @@ namespace nicoSWD\IfscCalendar\Infrastructure\Events;
 
 use Closure;
 use DateTimeImmutable;
-use DateTimeInterface;
 use Exception;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\GuzzleException;
@@ -322,7 +321,7 @@ final readonly class IFSCGuzzleEventsFetcher implements IFSCEventFetcherInterfac
 
     public function formatDate(DateTimeImmutable $scrapedRounds): string
     {
-        return $scrapedRounds->format(DateTimeInterface::RFC3339);
+        return $scrapedRounds->format('Y-m-d\TH:i:s');
     }
 
     private function getRoundName(object $round): string

--- a/src/Infrastructure/Events/IFSCGuzzleEventsFetcher.php
+++ b/src/Infrastructure/Events/IFSCGuzzleEventsFetcher.php
@@ -7,62 +7,106 @@
  */
 namespace nicoSWD\IfscCalendar\Infrastructure\Events;
 
+use Closure;
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\RequestOptions;
 use JsonException;
 use nicoSWD\IfscCalendar\Domain\Event\Exceptions\IFSCEventsScraperException;
+use nicoSWD\IfscCalendar\Domain\Event\Exceptions\InvalidURLException;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEventFetcherInterface;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCEventsScraper;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCScrapedEventsResult;
 use nicoSWD\IfscCalendar\Infrastructure\HttpClient\HttpGuzzleClient;
 
 final readonly class IFSCGuzzleEventsFetcher implements IFSCEventFetcherInterface
 {
     private const IFSC_LEAGUE_API_ENDPOINT = 'https://components.ifsc-climbing.org/results-api.php?api=season_leagues_calendar&league=%d';
 
+    private const IFSC_EVENT_API_ENDPOINT = 'https://ifsc.results.info/api/v1/events/%d';
+
+    private const IFSC_SESSION_COOKIE_NAME = '_verticallife_resultservice_session';
+
+    private const IFSC_RESULTS_INFO_PAGE = 'https://ifsc.results.info/';
+
     public function __construct(
-        private IFSCEventsScraper $eventsScraper,
-        private HttpGuzzleClient $client,
+        private IFSCRoundsScraper $roundsScraper,
+        private HttpGuzzleClient $httpClient,
+        private string $siteUrl,
     ) {
     }
 
     /**
      * @inheritdoc
      * @throws IFSCEventsScraperException
+     * @throws InvalidURLException
+     * @throws Exception
      */
-    public function fetchEventsForLeague(int $season, int $league): array
+    public function fetchEventsForLeague(int $season, int $leagueId): array
     {
-        $response = $this->fetchHtmlForLeague($league);
+        $sessionId = $this->fetchSessionIdCookie();
         $events = [];
 
-        foreach ($response->events as $event) {
-            $scrapedEvents = $this->eventsScraper->fetchEventsForLeague(
+        foreach ($this->fetchJsonEventsForLeague($leagueId)->events as $event) {
+            $scrapedRounds = $this->fetchScrapedRounds($season, $event);
+            $eventInfo = $this->fetchAdditionalEventInfo($event->event_id, $sessionId);
+
+            if (!empty($scrapedRounds->rounds)) {
+                $rounds = $scrapedRounds->rounds;
+            } else {
+                $rounds = $this->generateRounds($eventInfo);
+            }
+
+            $events[] = new IFSCEvent(
                 season: $season,
                 eventId: $event->event_id,
                 timeZone: $event->timezone->value,
                 eventName: $event->event,
+                location: $eventInfo->location,
+                country: $eventInfo->country,
+                poster: $scrapedRounds->poster,
+                siteUrl: $this->getSiteUrl($season, $event),
+                startsAt: $eventInfo->starts_at,
+                endsAt: $eventInfo->ends_at,
+                disciplines: $this->fetchDisciplines($eventInfo),
+                rounds: $rounds,
             );
-
-            if (empty($scrapedEvents)) {
-                // throw IFSCEventsScraperException::noEventsScrapedForEventWithName($event->event);
-            }
-
-            foreach ($scrapedEvents as $eventDetails) {
-                $events[] = $eventDetails;
-            }
         }
 
         return $events;
     }
 
-    public function buildLeagueUri(int $leagueId): string
+    /** @throws IFSCEventsScraperException */
+    private function fetchAdditionalEventInfo(int $eventId, string $sessionId): object
     {
-        return sprintf(self::IFSC_LEAGUE_API_ENDPOINT, $leagueId);
+        return $this->request($this->buildInfoUri($eventId), [
+            RequestOptions::HEADERS => [
+                // Apparently, this is required to pass the authorization check
+                'referer' => self::IFSC_RESULTS_INFO_PAGE,
+            ],
+            RequestOptions::COOKIES => CookieJar::fromArray(
+                cookies: [self::IFSC_SESSION_COOKIE_NAME => $sessionId],
+                domain: 'ifsc.results.info',
+            ),
+        ]);
     }
 
     /** @throws IFSCEventsScraperException */
-    public function fetchHtmlForLeague(int $league): object
+    private function fetchJsonEventsForLeague(int $leagueId): object
+    {
+        return $this->request($this->buildLeagueUri($leagueId));
+    }
+
+    /** @throws IFSCEventsScraperException */
+    private function request(string $url, array $options = []): object
     {
         try {
-            $response = $this->client->getRetry($this->buildLeagueUri($league));
+            $response = $this->httpClient->getRetry($url, $options);
 
             return @json_decode($response, flags: JSON_THROW_ON_ERROR);
         } catch (GuzzleException $e) {
@@ -70,5 +114,103 @@ final readonly class IFSCGuzzleEventsFetcher implements IFSCEventFetcherInterfac
         } catch (JsonException $e) {
             throw new IFSCEventsScraperException("Unable to parse JSON: {$e->getMessage()}");
         }
+    }
+
+    /** @throws IFSCEventsScraperException */
+    private function fetchSessionIdCookie(): string
+    {
+        try {
+            $headers = $this->httpClient->getHeaders(self::IFSC_RESULTS_INFO_PAGE);
+        }  catch (GuzzleException $e) {
+            throw new IFSCEventsScraperException("Unable to retrieve HTTP headers: {$e->getMessage()}");
+        }
+
+        $cookies = $headers['set-cookie'] ?? [];
+
+        foreach ($cookies as $cookie) {
+            if (str_starts_with($cookie, self::IFSC_SESSION_COOKIE_NAME)) {
+                [ , $value] = explode('=', $cookie, limit: 2);
+                [$sessionId] = explode(';', $value, limit: 2);
+
+                return $sessionId;
+            }
+        }
+
+        throw new IFSCEventsScraperException('Could not retrieve session cookie');
+    }
+
+    /**
+     * @throws InvalidURLException
+     * @throws IFSCEventsScraperException
+     */
+    private function fetchScrapedRounds(int $season, object $event): IFSCScrapedEventsResult
+    {
+        return $this->roundsScraper->fetchRoundsAndPosterForEvent(
+            season: $season,
+            eventId: $event->event_id,
+            timeZone: $event->timezone->value,
+        );
+    }
+
+    private function fetchDisciplines(object $info): array
+    {
+        $disciplines = [];
+
+        foreach ($info->disciplines as $discipline) {
+            $disciplines = array_merge($disciplines, explode('&', $discipline->kind));
+        }
+
+        return array_unique($disciplines);
+    }
+
+    /** @throws Exception */
+    private function generateRounds(object $eventInfo): array
+    {
+        $rounds = [];
+
+        foreach ($eventInfo->d_cats as $category) {
+            foreach ($category->category_rounds as $round) {
+                $rounds[] = new IFSCRound(
+                    name: sprintf("%s's %s %s", $round->category, ucfirst($round->kind), $round->name),
+                    streamUrl: null,
+                    startTime: $this->getStartTime($eventInfo),
+                    endTime: $this->getStartTime($eventInfo)->modify('+3 hours'),
+                    scheduleConfirmed: false,
+                );
+            }
+        }
+
+        return $rounds;
+    }
+
+    private function getSiteUrl(int $season, object $event): string
+    {
+        $params = [
+            'season' => $season,
+            'event_id' => $event->event_id,
+        ];
+
+        return preg_replace_callback('~{(?<var_name>season|event_id)}~', $this->replaceVariables($params), $this->siteUrl);
+    }
+
+    private function replaceVariables(array $params): Closure
+    {
+        return static fn (array $match): string => (string) $params[$match['var_name']];
+    }
+
+    private function buildLeagueUri(int $leagueId): string
+    {
+        return sprintf(self::IFSC_LEAGUE_API_ENDPOINT, $leagueId);
+    }
+
+    private function buildInfoUri(int $eventId): string
+    {
+        return sprintf(self::IFSC_EVENT_API_ENDPOINT, $eventId);
+    }
+
+    /** @throws Exception */
+    private function getStartTime(object $eventInfo): DateTimeImmutable
+    {
+        return new DateTimeImmutable($eventInfo->starts_at, new DateTimeZone($eventInfo->timezone->value));
     }
 }

--- a/src/Infrastructure/HttpClient/HttpGuzzleClient.php
+++ b/src/Infrastructure/HttpClient/HttpGuzzleClient.php
@@ -20,14 +20,14 @@ final readonly class HttpGuzzleClient implements HttpClientInterface
     }
 
     /** @throws GuzzleException */
-    public function getRetry(string $url): string
+    public function getRetry(string $url, array $options = []): string
     {
         $retryCount = 0;
         $html = '';
 
         do {
             try {
-                $html = $this->get($url);
+                $html = $this->get($url, $options);
             } catch (Exception $e) {
                 if (++$retryCount > 5) {
                     throw $e;
@@ -41,8 +41,14 @@ final readonly class HttpGuzzleClient implements HttpClientInterface
     }
 
     /** @throws GuzzleException */
-    private function get(string $url): string
+    public function getHeaders(string $url): array
     {
-        return $this->client->request('GET', $url)->getBody()->getContents();
+        return $this->client->request('GET', $url)->getHeaders();
+    }
+
+    /** @throws GuzzleException */
+    private function get(string $url, array $options): string
+    {
+        return $this->client->request('GET', $url, $options)->getBody()->getContents();
     }
 }

--- a/src/Infrastructure/YouTube/YouTubeVideoProvider.php
+++ b/src/Infrastructure/YouTube/YouTubeVideoProvider.php
@@ -7,6 +7,7 @@
  */
 namespace nicoSWD\IfscCalendar\Infrastructure\YouTube;
 
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeApiClient;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideo;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideoCollection;
@@ -20,7 +21,7 @@ final readonly class YouTubeVideoProvider implements YouTubeApiClient
     ) {
     }
 
-    public function fetchRecentVideos(int $season): YouTubeVideoCollection
+    public function fetchRecentVideos(IFSCSeasonYear $season): YouTubeVideoCollection
     {
         $videoCollection = new YouTubeVideoCollection();
 
@@ -32,9 +33,9 @@ final readonly class YouTubeVideoProvider implements YouTubeApiClient
     }
 
     /** @return IfscYouTubeVideo[] */
-    private function fetchLatestVideos(int $season): array
+    private function fetchLatestVideos(IFSCSeasonYear $season): array
     {
-        return $this->youTubeVideoCollection->getVideosForSeason($season);
+        return $this->youTubeVideoCollection->getVideosForSeason($season->value);
     }
 
     public function createVideo(IfscYouTubeVideo $item): YouTubeVideo

--- a/tests/unit/Domain/Calendar/Fixes/SeasonFix2023Test.php
+++ b/tests/unit/Domain/Calendar/Fixes/SeasonFix2023Test.php
@@ -8,9 +8,7 @@
 namespace nicoSWD\IfscCalendar\tests\Domain\Calendar\Fixes;
 
 use nicoSWD\IfscCalendar\Domain\Calendar\PostProcess\Season2023PostProcessor;
-use nicoSWD\IfscCalendar\Domain\Event\Helpers\DOMHelper;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCEventFactory;
-use nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
 use nicoSWD\IfscCalendar\tests\Helpers\MockHttpClient;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -24,10 +22,25 @@ final class SeasonFix2023Test extends TestCase
     #[Test]
     public function bern_2023_events_are_found(): void
     {
-        $events = [];
+        $events = [
+            new IFSCEvent(
+                season: 2023,
+                eventId: 1301,
+                timeZone: '',
+                eventName: '',
+                location: 'Jakata',
+                country: 'JPN',
+                poster: '',
+                siteUrl: '',
+                startsAt: '',
+                endsAt: '',
+                disciplines: [],
+                rounds: [],
+            ),
+        ];
         $newEvents = $this->season2023Fix->process($events);
 
-        $this->assertCount(19, $newEvents);
+        $this->assertCount(17, $newEvents[0]->rounds);
 
         [
             $event1,
@@ -40,16 +53,14 @@ final class SeasonFix2023Test extends TestCase
             $event8,
             $event9,
             $event10,
-            $event11,
             $event12,
             $event13,
             $event14,
             $event15,
-            $event16,
             $event17,
             $event18,
             $event19,
-        ] = $newEvents;
+        ] = $newEvents[0]->rounds;
 
         $this->assertSame('Men\'s Boulder Qualification', $event1->name);
         $this->assertSame('2023-08-01T09:00:00+02:00', $this->formatDate($event1->startTime));
@@ -81,9 +92,6 @@ final class SeasonFix2023Test extends TestCase
         $this->assertSame('Lead Finals', $event10->name);
         $this->assertSame('2023-08-06T18:30:00+02:00', $this->formatDate($event10->startTime));
 
-        $this->assertSame('Paraclimbing Qualifications', $event11->name);
-        $this->assertSame('2023-08-08T09:00:00+02:00', $this->formatDate($event11->startTime));
-
         $this->assertSame('Women\'s Boulder & Lead Semi-final', $event12->name);
         $this->assertSame('2023-08-09T09:00:00+02:00', $this->formatDate($event12->startTime));
 
@@ -95,9 +103,6 @@ final class SeasonFix2023Test extends TestCase
 
         $this->assertSame('Speed Qualifications', $event15->name);
         $this->assertSame('2023-08-10T09:00:00+02:00', $this->formatDate($event15->startTime));
-
-        $this->assertSame('Paraclimbing Finals', $event16->name);
-        $this->assertSame('2023-08-10T14:00:00+02:00', $this->formatDate($event16->startTime));
 
         $this->assertSame('Speed Finals', $event17->name);
         $this->assertSame('2023-08-10T20:00:00+02:00', $this->formatDate($event17->startTime));
@@ -111,12 +116,7 @@ final class SeasonFix2023Test extends TestCase
 
     protected function setUp(): void
     {
-        $this->season2023Fix = new Season2023PostProcessor(
-            $this->mockClientReturningFile('bern_2023.html'),
-            new IFSCEventFactory('https://ifsc.stream/#/season/%d/event/%d', new Normalizer()),
-            new Normalizer(),
-            new DOMHelper(),
-        );
+        $this->season2023Fix = new Season2023PostProcessor();
 
         parent::setUp();
     }

--- a/tests/unit/Domain/Calendar/Fixes/SeasonFix2023Test.php
+++ b/tests/unit/Domain/Calendar/Fixes/SeasonFix2023Test.php
@@ -9,6 +9,7 @@ namespace nicoSWD\IfscCalendar\tests\Domain\Calendar\Fixes;
 
 use nicoSWD\IfscCalendar\Domain\Calendar\PostProcess\Season2023PostProcessor;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 use nicoSWD\IfscCalendar\tests\Helpers\MockHttpClient;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
@@ -24,7 +25,7 @@ final class SeasonFix2023Test extends TestCase
     {
         $events = [
             new IFSCEvent(
-                season: 2023,
+                season: IFSCSeasonYear::SEASON_2023,
                 eventId: 1301,
                 timeZone: '',
                 eventName: '',

--- a/tests/unit/Domain/Event/IFSCEventsScraperTest.php
+++ b/tests/unit/Domain/Event/IFSCEventsScraperTest.php
@@ -12,6 +12,7 @@ use nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer;
 use nicoSWD\IfscCalendar\Domain\Round\IFSCRoundFactory;
 use nicoSWD\IfscCalendar\Domain\Round\IFSCRoundsScraper;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCScrapedEventsResult;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 use nicoSWD\IfscCalendar\tests\Helpers\MockHttpClient;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -271,7 +272,7 @@ final class IFSCEventsScraperTest extends TestCase
         );
 
         return $eventScraper->fetchRoundsAndPosterForEvent(
-            season: 2023,
+            season: IFSCSeasonYear::SEASON_2023,
             eventId: 1249,
             timeZone: $timeZone,
         );

--- a/tests/unit/Domain/Event/IFSCEventsScraperTest.php
+++ b/tests/unit/Domain/Event/IFSCEventsScraperTest.php
@@ -9,8 +9,8 @@ namespace nicoSWD\IfscCalendar\tests\Domain\Event;
 
 use nicoSWD\IfscCalendar\Domain\Event\Helpers\DOMHelper;
 use nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper;
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRoundFactory;
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRoundsScraper;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCScrapedEventsResult;
 use nicoSWD\IfscCalendar\tests\Helpers\MockHttpClient;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/unit/Domain/Event/IFSCEventsScraperTest.php
+++ b/tests/unit/Domain/Event/IFSCEventsScraperTest.php
@@ -9,9 +9,9 @@ namespace nicoSWD\IfscCalendar\tests\Domain\Event;
 
 use nicoSWD\IfscCalendar\Domain\Event\Helpers\DOMHelper;
 use nicoSWD\IfscCalendar\Domain\Event\Helpers\Normalizer;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCEventFactory;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCEventsScraper;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCRoundFactory;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCRoundsScraper;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCScrapedEventsResult;
 use nicoSWD\IfscCalendar\tests\Helpers\MockHttpClient;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -26,16 +26,13 @@ final class IFSCEventsScraperTest extends TestCase
         $events = $this->fetchEventsFromFile(
             fileName: 'hachioji_2023.html',
             timeZone: 'Asia/Tokyo',
-            eventName: 'IFSC - Climbing World Cup (B,S) - Seoul (KOR) 2023',
         );
 
-        $this->assertCount(5, $events);
+        $this->assertCount(5, $events->rounds);
 
-        [$event1, $event2, $event3, $event4, $event5] = $events;
+        [$event1, $event2, $event3, $event4, $event5] = $events->rounds;
 
-        $this->assertSame(1249, $event1->id);
-        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2023/230422_Hachioji_WC/a._Poster_HACH23.jpg', $event1->poster);
-        $this->assertSame('IFSC - Climbing World Cup (B,S) - Seoul (KOR) 2023', $event1->description);
+        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2023/230422_Hachioji_WC/a._Poster_HACH23.jpg', $events->poster);
 
         $this->assertSame('Boulder Qualifications', $event1->name);
         $this->assertSame('2023-04-21T09:00:00+09:00', $this->formatDate($event1->startTime));
@@ -69,16 +66,13 @@ final class IFSCEventsScraperTest extends TestCase
         $events = $this->fetchEventsFromFile(
             fileName: 'seoul_2023.html',
             timeZone: 'Asia/Seoul',
-            eventName: 'IFSC - Climbing World Cup (B) - Hachioji (JPN) 2023',
         );
 
-        $this->assertCount(5, $events);
+        $this->assertCount(5, $events->rounds);
 
-        [$event1, $event2, $event3, $event4, $event5] = $events;
+        [$event1, $event2, $event3, $event4, $event5] = $events->rounds;
 
-        $this->assertSame(1249, $event1->id);
-        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2023/230428_Seoul_WC/230329_Poster_SEOUL23.jpg', $event1->poster);
-        $this->assertSame('IFSC - Climbing World Cup (B) - Hachioji (JPN) 2023', $event1->description);
+        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2023/230428_Seoul_WC/230329_Poster_SEOUL23.jpg', $events->poster);
 
         $this->assertSame('Speed Qualifications', $event1->name);
         $this->assertSame('2023-04-28T12:15:00+09:00', $this->formatDate($event1->startTime));
@@ -112,16 +106,13 @@ final class IFSCEventsScraperTest extends TestCase
         $events = $this->fetchEventsFromFile(
             fileName: 'jakata_2023.html',
             timeZone: 'Asia/Jakarta',
-            eventName: 'IFSC - Climbing World Cup (S) - Jakarta (INA) 2023',
         );
 
-        $this->assertCount(2, $events);
+        $this->assertCount(2, $events->rounds);
 
-        [$event1, $event2] = $events;
+        [$event1, $event2] = $events->rounds;
 
-        $this->assertSame(1249, $event1->id);
-        $this->assertSame('', $event1->poster);
-        $this->assertSame('IFSC - Climbing World Cup (S) - Jakarta (INA) 2023', $event1->description);
+        $this->assertSame(null, $events->poster);
 
         $this->assertSame('Speed Qualifications', $event1->name);
         $this->assertSame('2023-05-06T08:00:00+07:00', $this->formatDate($event1->startTime));
@@ -140,16 +131,13 @@ final class IFSCEventsScraperTest extends TestCase
         $events = $this->fetchEventsFromFile(
             fileName: 'jakata_2023_malformed.html',
             timeZone: 'Asia/Jakarta',
-            eventName: 'IFSC - Climbing World Cup (S) - Jakarta (INA) 2023',
         );
 
-        $this->assertCount(2, $events);
+        $this->assertCount(2, $events->rounds);
 
-        [$event1, $event2] = $events;
+        [$event1, $event2] = $events->rounds;
 
-        $this->assertSame(1249, $event1->id);
-        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2023/230506_Jakarta_WC/230415_Poster_JAK23v2.jpg', $event1->poster);
-        $this->assertSame('IFSC - Climbing World Cup (S) - Jakarta (INA) 2023', $event1->description);
+        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2023/230506_Jakarta_WC/230415_Poster_JAK23v2.jpg', $events->poster);
 
         $this->assertSame('Speed Qualifications', $event1->name);
         $this->assertSame('2023-05-06T18:15:00+07:00', $this->formatDate($event1->startTime));
@@ -168,16 +156,13 @@ final class IFSCEventsScraperTest extends TestCase
         $events = $this->fetchEventsFromFile(
             fileName: 'salt_lake_city_2023.html',
             timeZone: 'America/Denver',
-            eventName: 'IFSC - Climbing World Cup (B,S) - Salt Lake City (USA) 2023',
         );
 
-        $this->assertCount(10, $events);
+        $this->assertCount(10, $events->rounds);
 
-        [$event1, $event2, $event3, $event4, $event5, $event6, $event7, $event8, $event9, $event10] = $events;
+        [$event1, $event2, $event3, $event4, $event5, $event6, $event7, $event8, $event9, $event10] = $events->rounds;
 
-        $this->assertSame(1249, $event1->id);
-        $this->assertSame('', $event1->poster);
-        $this->assertSame('IFSC - Climbing World Cup (B,S) - Salt Lake City (USA) 2023', $event1->description);
+        $this->assertSame(null, $events->poster);
 
         $this->assertSame('Women\'s Boulder Qualification', $event1->name);
         $this->assertSame('2023-05-19T09:00:00-06:00', $this->formatDate($event1->startTime));
@@ -236,15 +221,13 @@ final class IFSCEventsScraperTest extends TestCase
         $events = $this->fetchEventsFromFile(
             fileName: 'meiringen_2022.html',
             timeZone: 'Europe/Zurich',
-            eventName: 'IFSC - Climbing World Cup (B) - Meiringen (SUI) 2022',
         );
 
-        $this->assertCount(6, $events);
+        $this->assertCount(6, $events->rounds);
 
-        [$event1, $event2, $event3, $event4, $event5, $event6] = $events;
+        [$event1, $event2, $event3, $event4, $event5, $event6] = $events->rounds;
 
-        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2022/220408_Meiringen_WC/IFSC_WC_MEIRINGEN22_poster.jpg', $event1->poster);
-        $this->assertSame('IFSC - Climbing World Cup (B) - Meiringen (SUI) 2022', $event1->description);
+        $this->assertSame('https://cdn.ifsc-climbing.org/images/Events/2022/220408_Meiringen_WC/IFSC_WC_MEIRINGEN22_poster.jpg', $events->poster);
 
         $this->assertSame('Women\'s Boulder Qualification', $event1->name);
         $this->assertSame('2023-04-08T09:00:00+02:00', $this->formatDate($event1->startTime));
@@ -277,21 +260,20 @@ final class IFSCEventsScraperTest extends TestCase
         $this->assertSame('https://youtu.be/HPNpg-pLZOg', $event6->streamUrl);
     }
 
-    /** @return IFSCEvent[] */
-    private function fetchEventsFromFile(string $fileName, string $timeZone, string $eventName): array
+    /** @return IFSCScrapedEventsResult */
+    private function fetchEventsFromFile(string $fileName, string $timeZone): IFSCScrapedEventsResult
     {
-        $eventScraper = new IFSCEventsScraper(
+        $eventScraper = new IFSCRoundsScraper(
             $this->mockClientReturningFile($fileName),
-            new IFSCEventFactory('https://ifsc.stream/#/event/%d', new Normalizer()),
+            new IFSCRoundFactory(new Normalizer()),
             new DOMHelper(),
             new Normalizer(),
         );
 
-        return $eventScraper->fetchEventsForLeague(
+        return $eventScraper->fetchRoundsAndPosterForEvent(
             season: 2023,
             eventId: 1249,
             timeZone: $timeZone,
-            eventName: $eventName,
         );
     }
 }

--- a/tests/unit/Domain/YouTube/YouTubeLinkMatcherTest.php
+++ b/tests/unit/Domain/YouTube/YouTubeLinkMatcherTest.php
@@ -10,6 +10,7 @@ namespace nicoSWD\IfscCalendar\tests\Domain\YouTube;
 use DateTimeImmutable;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
 use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Season\IFSCSeasonYear;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeLinkMatcher;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideo;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideoCollection;
@@ -26,6 +27,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Speed Qualifications',
             description: 'IFSC World Cup Seoul 2023',
+            location: 'Seoul',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/mC1RhpB4uuQ', $event);
@@ -37,6 +39,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Speed Finals',
             description: 'IFSC World Cup Seoul 2023',
+            location: 'Seoul',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/eIa6VYrfqX8', $event);
@@ -49,6 +52,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Women\'s Boulder Qualification',
             description: 'IFSC World Cup Seoul 2023',
+            location: 'Seoul',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -60,6 +64,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Men\'s Boulder Qualification',
             description: 'IFSC World Cup Seoul 2023',
+            location: 'Seoul',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -71,6 +76,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Boulder Semi-finals',
             description: 'IFSC World Cup Seoul 2023',
+            location: 'Seoul',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -82,6 +88,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Boulder Qualifications',
             description: 'IFSC World Cup Hachioji 2023',
+            location: 'Hachioji',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -93,6 +100,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Women\'s Boulder Semi-final',
             description: 'IFSC World Cup Hachioji 2023',
+            location: 'Hachioji',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/kuE-qhRq7Fk', $event);
@@ -104,6 +112,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Women\'s Speed Qualification',
             description: 'IFSC World Cup Salt Lake City 2023',
+            location: 'Salt Lake City',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/n6YyV2ddbb4', $event);
@@ -115,6 +124,7 @@ final class YouTubeLinkMatcherTest extends TestCase
         $event = $this->createEventWithNameAndDescription(
             name: 'Men\'s Lead Final',
             description: 'IFSC World Cup Chamonix 2023',
+            location: 'Chamonix',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/ZNgbe8vi2OI', $event);
@@ -162,14 +172,14 @@ final class YouTubeLinkMatcherTest extends TestCase
         return $videoCollection;
     }
 
-    private function createEventWithNameAndDescription(string $name, string $description): IFSCEvent
+    private function createEventWithNameAndDescription(string $name, string $description, string $location): IFSCEvent
     {
         return new IFSCEvent(
-            season: 2023,
+            season: IFSCSeasonYear::SEASON_2023,
             eventId: 1292,
             timeZone: '',
             eventName: $description,
-            location: 'Jakata',
+            location: $location,
             country: 'JPN',
             poster: 'https://cdn.ifsc-climbing.org/images/Events/2023/230506_Jakarta_WC/230415_Poster_JAK23.jpg',
             siteUrl: '',

--- a/tests/unit/Domain/YouTube/YouTubeLinkMatcherTest.php
+++ b/tests/unit/Domain/YouTube/YouTubeLinkMatcherTest.php
@@ -9,7 +9,7 @@ namespace nicoSWD\IfscCalendar\tests\Domain\YouTube;
 
 use DateTimeImmutable;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
-use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
+use nicoSWD\IfscCalendar\Domain\Round\IFSCRound;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeLinkMatcher;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideo;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideoCollection;

--- a/tests/unit/Domain/YouTube/YouTubeLinkMatcherTest.php
+++ b/tests/unit/Domain/YouTube/YouTubeLinkMatcherTest.php
@@ -9,6 +9,7 @@ namespace nicoSWD\IfscCalendar\tests\Domain\YouTube;
 
 use DateTimeImmutable;
 use nicoSWD\IfscCalendar\Domain\Event\IFSCEvent;
+use nicoSWD\IfscCalendar\Domain\Event\IFSCRound;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeLinkMatcher;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideo;
 use nicoSWD\IfscCalendar\Domain\YouTube\YouTubeVideoCollection;
@@ -24,7 +25,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Speed Qualifications',
-            description: 'IFSC - Climbing World Cup (B,S) - Seoul (KOR) 2023',
+            description: 'IFSC World Cup Seoul 2023',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/mC1RhpB4uuQ', $event);
@@ -35,7 +36,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Speed Finals',
-            description: 'IFSC - Climbing World Cup (B,S) - Seoul (KOR) 2023',
+            description: 'IFSC World Cup Seoul 2023',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/eIa6VYrfqX8', $event);
@@ -47,7 +48,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Women\'s Boulder Qualification',
-            description: 'IFSC - Climbing World Cup (B,S) - Seoul (KOR) 2023',
+            description: 'IFSC World Cup Seoul 2023',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -58,7 +59,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Men\'s Boulder Qualification',
-            description: 'IFSC - Climbing World Cup (B,S) - Seoul (KOR) 2023',
+            description: 'IFSC World Cup Seoul 2023',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -69,7 +70,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Boulder Semi-finals',
-            description: 'IFSC - Climbing World Cup (B,S) - Seoul (KOR) 2023',
+            description: 'IFSC World Cup Seoul 2023',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -80,7 +81,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Boulder Qualifications',
-            description: 'IFSC - Climbing World Cup (B) - Hachioji (JPN) 2023',
+            description: 'IFSC World Cup Hachioji 2023',
         );
 
         $this->assertNull($this->findStreamUrlForEvent($event));
@@ -91,7 +92,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Women\'s Boulder Semi-final',
-            description: 'IFSC - Climbing World Cup (B) - Hachioji (JPN) 2023',
+            description: 'IFSC World Cup Hachioji 2023',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/kuE-qhRq7Fk', $event);
@@ -102,7 +103,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Women\'s Speed Qualification',
-            description: 'IFSC - Climbing World Cup (B,S) - Salt Lake City (USA) 2023',
+            description: 'IFSC World Cup Salt Lake City 2023',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/n6YyV2ddbb4', $event);
@@ -113,7 +114,7 @@ final class YouTubeLinkMatcherTest extends TestCase
     {
         $event = $this->createEventWithNameAndDescription(
             name: 'Men\'s Lead Final',
-            description: 'World Cup (L,S) - Chamonix (FRA) 2023',
+            description: 'IFSC World Cup Chamonix 2023',
         );
 
         $this->assetUrlMatchesEvent('https://youtu.be/ZNgbe8vi2OI', $event);
@@ -145,7 +146,6 @@ final class YouTubeLinkMatcherTest extends TestCase
             "iF_1fI21Z_w" => "Lead semi-finals || Chamonix 2023",
             "3zfs3s06yPQ" => "Speed finals || Chamonix 2023",
             "h6EYmiImp5g" => "Speed qualifications || Chamonix 2023",
-
         ];
 
         $videoCollection = new YouTubeVideoCollection();
@@ -165,20 +165,31 @@ final class YouTubeLinkMatcherTest extends TestCase
     private function createEventWithNameAndDescription(string $name, string $description): IFSCEvent
     {
         return new IFSCEvent(
-            name: $name,
-            id: 1292,
-            description: $description,
-            streamUrl: '',
-            siteUrl: '',
+            season: 2023,
+            eventId: 1292,
+            timeZone: '',
+            eventName: $description,
+            location: 'Jakata',
+            country: 'JPN',
             poster: 'https://cdn.ifsc-climbing.org/images/Events/2023/230506_Jakarta_WC/230415_Poster_JAK23.jpg',
-            startTime: new DateTimeImmutable('2023-09-23T19:30:00+08:00'),
-            endTime: new DateTimeImmutable('2023-09-23T21:30:00+08:00'),
+            siteUrl: '',
+            startsAt: '2023-09-23T19:30:00+08:00',
+            endsAt: '2023-09-23T21:30:00+08:00',
+            disciplines: [],
+            rounds: [
+                new IFSCRound(
+                    name: $name,
+                    streamUrl: '',
+                    startTime: new DateTimeImmutable(),
+                    endTime: new DateTimeImmutable(),
+                )
+            ],
         );
     }
 
     private function findStreamUrlForEvent(IFSCEvent $event): ?string
     {
-        return $this->linkMatcher->findStreamUrlForEvent($event, $this->createVideoCollection());
+        return $this->linkMatcher->findStreamUrlForRound($event->rounds[0], $event, $this->createVideoCollection());
     }
 
     private function assetUrlMatchesEvent(string $url, IFSCEvent $event): void

--- a/tests/unit/Helpers/MockHttpClient.php
+++ b/tests/unit/Helpers/MockHttpClient.php
@@ -24,6 +24,11 @@ trait MockHttpClient
             {
                 return file_get_contents($this->fileName);
             }
+
+            public function getRetry(string $url): string
+            {
+                return $this->get($url);
+            }
         };
     }
 


### PR DESCRIPTION
Big refactor including:

 - Get some event info (not available on site) from an API
 - Fix poster scraper for older seasons
 - Scrape date range (as the date from the API is inaccurate)
 - Add athlete start list to `.json` and `.ics`
 - Add disciplines
 - Hard-coded Bern events as the page I used to scrape no longer exists
 - Add date range to calendar if no events have been published yet
 - Found a way to authenticate to an API that appeared to be protected
 - ...